### PR TITLE
Added setting for hiding inactive bar by default

### DIFF
--- a/src/main.moon
+++ b/src/main.moon
@@ -22,6 +22,12 @@ if settings['enable-bar']
 		if chapters
 			chapters\toggleInactiveVisibility!
 
+if settings['hide-inactive-bar']
+	barBackground\toggleInactiveVisibility!
+	progressBar\toggleInactiveVisibility!
+	if chapters
+		chapters\toggleInactiveVisibility!
+
 if settings['enable-chapter-markers']
 	chapters = Chapters animationQueue
 	aggregator\addSubscriber chapters

--- a/src/settings.moon
+++ b/src/settings.moon
@@ -22,6 +22,8 @@ settings = {
 	--[=[ progress bar options ]=]--
 	-- whether or not to draw the progress bar at all.
 	'enable-bar': true
+	-- whether the inactive bar should be hidden until toggled.
+	'hide-inactive-bar': false
 	-- [[ bar size options ]] --
 	-- Inactive bar height. Pixels. Bar is invisible when inactive if 0.
 	'bar-height-inactive': 2


### PR DESCRIPTION
I know, this isn't contributing to improving the code quality. Still seemed like the sanest and quickest way to add a setting without digging too deep into moonscript.