### PR TITLE
Added a setting for hiding inactive elements

### DIFF
--- a/src/ChapterMarker.moon
+++ b/src/ChapterMarker.moon
@@ -21,7 +21,6 @@ class ChapterMarker
 		}
 
 		@passed = false
-		@minHeight = minHeight
 
 	stringify: =>
 		return table.concat @line
@@ -32,7 +31,7 @@ class ChapterMarker
 
 	animateSize: ( value ) =>
 		@line[4] = [[%g]]\format (maxWidth - minWidth)*value + minWidth
-		@line[6] = [[%g]]\format (maxHeight*maxHeightFrac - @minHeight)*value + @minHeight
+		@line[6] = [[%g]]\format (maxHeight*maxHeightFrac - minHeight)*value + minHeight
 
 	update: ( position ) =>
 		update = false

--- a/src/Chapters.moon
+++ b/src/Chapters.moon
@@ -8,7 +8,6 @@ class Chapters extends Subscriber
 		@line = { }
 		@markers = { }
 		@animation = Animation 0, 1, 0.25, @\animateSize
-		@visible = true
 
 	createMarkers: ( w, h ) =>
 		@line = { }
@@ -21,16 +20,6 @@ class Chapters extends Subscriber
 			marker = ChapterMarker chapter.time/totalTime, w, h
 			table.insert @markers, marker
 			table.insert @line, marker\stringify!
-
-	toggleInactiveVisibility: =>
-		value = @visible and 0 or minHeight
-		for i, marker in ipairs @markers
-			marker.minHeight = value
-			marker.line[6] = value if not @hovered
-			@line[i] = marker\stringify!
-
-		@visible = not @visible
-		@needsUpdate = true
 
 	stringify: =>
 		return table.concat @line, '\n'

--- a/src/OSDAggregator.moon
+++ b/src/OSDAggregator.moon
@@ -7,6 +7,8 @@ class OSDAggregator
 		@subscriberCount = 0
 		@w = 0
 		@h = 0
+		@hideInactive = settings['hide-inactive']
+		@needsRedrawAll = false
 
 		@updateTimer = mp.add_periodic_timer settings['redraw-period'], @\update
 
@@ -77,12 +79,17 @@ class OSDAggregator
 			update = false
 			if theSub\update @inputState
 				update = true
-			if (needsResize and theSub\updateSize( w, h )) or update
+			if (needsResize and theSub\updateSize( w, h )) or update or @needsRedrawAll
 				needsRedraw = true
-				@script[sub] = theSub\stringify!
+				if @hideInactive and not theSub.hovered
+					@script[sub] = nil
+				else
+					@script[sub] = theSub\stringify!
 
 		if needsRedraw == true
 			mp.set_osd_ass @w, @h, table.concat @script, '\n'
+
+		@needsRedrawAll = false
 
 	pause: ( event, @paused ) =>
 		if @paused
@@ -95,3 +102,7 @@ class OSDAggregator
 		@update true
 		unless @paused
 			@updateTimer\resume!
+
+	toggleInactiveVisibility: =>
+		@hideInactive = not @hideInactive
+		@needsRedrawAll = true

--- a/src/ProgressBar.moon
+++ b/src/ProgressBar.moon
@@ -19,14 +19,6 @@ class ProgressBar extends Subscriber
 
 		@lastPosition = 0
 		@animation = Animation minHeight, maxHeight, 0.25, @\animateHeight
-		@visible = true
-
-	toggleInactiveVisibility: =>
-		value = @visible and 0 or minHeight
-		@animation.initialValue = value
-		@line[6] = value if not @hovered
-		@visible = not @visible
-		@needsUpdate = true
 
 	stringify: =>
 		return table.concat @line

--- a/src/ProgressBarBackground.moon
+++ b/src/ProgressBarBackground.moon
@@ -16,14 +16,6 @@ class ProgressBarBackground extends Subscriber
 		}
 
 		@animation = Animation minHeight, maxHeight, 0.25, @\animateHeight
-		@visible = true
-
-	toggleInactiveVisibility: =>
-		value = @visible and 0 or minHeight
-		@animation.initialValue = value
-		@line[4] = value if not @hovered
-		@visible = not @visible
-		@needsUpdate = true
 
 	stringify: =>
 		return table.concat @line

--- a/src/main.moon
+++ b/src/main.moon
@@ -17,10 +17,7 @@ if settings['enable-bar']
 				mp.commandv "seek", x*100/progressBar.w, "absolute-percent+#{settings['seek-precision']}"
 
 	mp.add_key_binding "c", "toggle-inactive-bar", ->
-		barBackground\toggleInactiveVisibility!
-		progressBar\toggleInactiveVisibility!
-		if chapters
-			chapters\toggleInactiveVisibility!
+		aggregator\toggleInactiveVisibility!
 
 if settings['enable-chapter-markers']
 	chapters = Chapters animationQueue

--- a/src/settings.moon
+++ b/src/settings.moon
@@ -22,6 +22,8 @@ settings = {
 	--[=[ progress bar options ]=]--
 	-- whether or not to draw the progress bar at all.
 	'enable-bar': true
+	-- Hide elements even when they are inactive.
+	'hide-inactive': false
 	-- [[ bar size options ]] --
 	-- Inactive bar height. Pixels. Bar is invisible when inactive if 0.
 	'bar-height-inactive': 2


### PR DESCRIPTION
Different version of #16, largely reverting a8416518dbc3a94cdd5cd759deb62334b002c083 and moving functionality to Subscriber

Known bugs:
- The title does not appear when using the request-display command while
  inactive element hiding is enabled
- Elements disappear immediately when element hiding is enabled instead
  of being animated